### PR TITLE
Add workflows for path-with-traversals GFA 1.0 and parquet formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *~
+.nextflow
+.nextflow*
+work

--- a/main.nf
+++ b/main.nf
@@ -1,0 +1,116 @@
+#!/usr/bin/env nextflow
+
+params.dir = "${baseDir}"
+params.threads = 4
+params.readLength = 2000
+params.alignmentReadLength = 1000
+
+fastqFiles = "${params.dir}/**.fastq"
+fastqs = Channel.fromPath(fastqFiles).map { path -> tuple(path.baseName, path) }
+
+process filterShortReads {
+  tag { sample }
+  container "quay.io/glennhickey/pigz:2.3.1" // todo: might not have tr & awk
+
+  input:
+    set sample, file(fastq) from fastqs
+  output:
+    set sample, file("${sample}.filtered.fastq.gz") into filtered
+
+  shell:
+  '''
+  cat $fastq \
+    | paste - - - - \
+    | tr ' ' '_' \
+    | awk 'length($2) > !{params.readLength} { print $1; print $2; print $3; print $4; }' \
+    | pigz > ${sample}.filtered.fastq.gz
+  '''
+}
+
+/*
+process minimap2Index {
+  tag { sample }
+  container "quay.io/biocontainers/minimap2:2.17--h8b12597_1"
+
+  input:
+    set sample, file(fastq) from filtered
+  output:
+    set sample, $fastq, file("${sample}.mmi") into indexed
+
+  """
+  minimap2 -w 1 -d ${sample}.mmi $fastq
+  """    
+}
+
+process minimap2 {
+  tag { sample }
+  container "quay.io/biocontainers/minimap2:2.17--h8b12597_1"
+
+  input:
+    set sample, file(fastq), file(index) from indexed
+  output:
+    set sample, $fastq, file("${sample}.paf") into alignments
+
+  """
+  minimap2 -c -w 1 -X -t ${params.threads} -d $index $fastq > ${sample}.paf
+  """
+}
+*/
+
+process minimap2NoIndex {
+  tag { sample }
+  container "quay.io/biocontainers/minimap2:2.17--h8b12597_1"
+
+  input:
+    set sample, file(fastq), file(index) from filtered
+  output:
+    set sample, $fastq, file("${sample}.paf") into alignments
+
+  """
+  minimap2 -c -w 1 -X -t ${params.threads} $fastq $fastq > ${sample}.paf
+  """
+}
+
+process filterShortAlignments {
+  tag { sample }
+  container "quay.io/biocontainers/fpa:0.5--hbcae180_2"
+
+  input:
+    set sample, file(fastq), file(alignment) from alignments
+  output:
+    set sample, $fastq, file("${sample}.filtered.paf") into filteredAlignments
+
+  """
+  fpa drop -l ${params.alignmentReadLength} < $alignment > ${sample}.filtered.paf
+  """
+}
+
+process seqwish {
+  tag { sample }
+  container ""
+
+  input:
+    set sample, file(fastq), file(alignment) from filteredAlignments
+  output:
+    set sample, file("${sample}.gfa") into graphs
+
+  """
+  seqwish -t ${params.threads} -k 16 -s $fastq -p $alignment -g ${sample}.gfa
+  """
+}
+
+process graphSimplification {
+  tag { sample }
+  container "quay.io/biocontainers/odgi:0.2--py37h8b12597_0"
+
+  input:
+    set sample, file(graph) from graphs
+  output:
+    set sample, file("${sample}.odgi-prune.b3.gfa") into simplifiedGraphs
+
+  """
+  odgi build -g $graph -o - \
+    | odgi prune -i - -b 3 -o - \
+    | odgi view -i - -g >${sample}.odgi-prune.b3.gfa
+  """
+}

--- a/main.nf
+++ b/main.nf
@@ -130,7 +130,7 @@ process graphSimplification {
 
   """
   odgi build -g $graph -o - \
-    | odgi prune -i - -b 3 -o - \
+    | odgi prune -k 16 -i - -o - \
     | odgi view -i - -g >${sample}.odgi-prune.b3.gfa
   """
 }

--- a/main.nf
+++ b/main.nf
@@ -121,7 +121,7 @@ process seqwish {
 
 process graphSimplification {
   tag { sample }
-  container "quay.io/biocontainers/odgi:0.2--py37h8b12597_0"
+  container "heuermh/odgi-dev:latest"
 
   input:
     set sample, file(graph) from graphs
@@ -130,7 +130,17 @@ process graphSimplification {
 
   """
   odgi build -g $graph -o - \
+    | odgi prune -i - -b 3 -o - \
+    | odgi view -i - -g >${sample}.odgi-prune.b3.gfa
+  """
+
+/*
+  //container "quay.io/biocontainers/odgi:0.2--py37h8b12597_0"
+
+  """
+  odgi build -g $graph -o - \
     | odgi prune -k 16 -i - -o - \
     | odgi view -i - -g >${sample}.odgi-prune.b3.gfa
   """
+*/
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,20 @@
+profiles
+{
+  // standard profile runs by default
+  standard
+  {
+    // increase --driver-memory if necessary
+    params.sparkOpts = '--master local[*] --driver-memory 12G'
+  }
+  // add docker profile to run with docker
+  docker
+  {
+    docker.enabled = true
+  }
+  // use yarn profile to run on e.g. AWS EMR
+  yarn
+  {
+    // --driver-memory, --driver-cores, --executor-memory, --executor-cores, --num-executors, etc.
+    params.sparkOpts = '--master yarn-client'
+  }
+}

--- a/toParquet.nf
+++ b/toParquet.nf
@@ -1,0 +1,48 @@
+#!/usr/bin/env nextflow
+
+params.dir = "${baseDir}/PRJNA607948"
+params.jar = "https://repo1.maven.org/maven2/com/github/heuermh/adamgfa/adam-gfa_2.11/0.4.0/adam-gfa_2.11-0.4.0.jar"
+
+gfaFiles = "${params.dir}/**.gfa"
+gfas = Channel.fromPath(gfaFiles).map { path -> tuple(path.baseName, path.toRealPath().getParent(), path) }
+(toDataframe, toDataframes) = gfas.into(2)
+
+process toDataframe {
+  tag { sample }
+  publishDir "$parent", mode: 'move'
+  container "quay.io/biocontainers/adam:0.31.0--0"
+
+  input:
+    set sample, parent, file(gfa) from toDataframe
+  output:
+    set sample, parent, file("${sample}.parquet") into dataframe
+
+  """
+  spark-submit ${params.sparkOpts} \
+    --conf spark.sql.parquet.compression.codec=gzip \
+    --class com.github.heuermh.adam.gfa.Gfa1ToDataframe \
+    ${params.jar} \
+    $gfa \
+    ${sample}.parquet
+  """
+}
+
+process toDataframes {
+  tag { sample }
+  publishDir "$parent", mode: 'move'
+  container "quay.io/biocontainers/adam:0.31.0--0"
+
+  input:
+    set sample, parent, file(gfa) from toDataframes
+  output:
+    set sample, parent, file("${sample}*.parquet") into dataframes
+
+  """
+  spark-submit ${params.sparkOpts} \
+    --conf spark.sql.parquet.compression.codec=gzip \
+    --class com.github.heuermh.adam.gfa.Gfa1ToDataframes \
+    ${params.jar} \
+    $gfa \
+    ${sample}
+  """
+}

--- a/withTraversals.nf
+++ b/withTraversals.nf
@@ -8,7 +8,7 @@ gfas = Channel.fromPath(gfaFiles).map { path -> tuple(path.baseName, path.toReal
 process withTraversals {
   tag { sample }
   publishDir "$parent", mode: 'move'
-  container "quay.io/biocontainers/dsh-bio:1.3.2--0"
+  container "quay.io/biocontainers/dsh-bio:1.3.3--0"
 
   input:
     set sample, parent, file(gfa) from gfas

--- a/withTraversals.nf
+++ b/withTraversals.nf
@@ -1,0 +1,21 @@
+#!/usr/bin/env nextflow
+
+params.dir = "${baseDir}/PRJNA607948"
+
+gfaFiles = "${params.dir}/**.gfa"
+gfas = Channel.fromPath(gfaFiles).map { path -> tuple(path.baseName, path.toRealPath().getParent(), path) }
+
+process withTraversals {
+  tag { sample }
+  publishDir "$parent", mode: 'move'
+  container "quay.io/biocontainers/dsh-bio:1.3.2--0"
+
+  input:
+    set sample, parent, file(gfa) from gfas
+  output:
+    set sample, parent, file("${sample}.withTraversals.gfa") into withTraversals
+
+  """
+  dsh-bio traverse-paths -i $gfa | dsh-bio truncate-paths -o ${sample}.withTraversals.gfa
+  """
+}


### PR DESCRIPTION
Not sure what you think of [Nextflow](https://www.nextflow.io/); I like it because you can run the same workflow locally
```
$ nextflow run toParquet.nf
```

locally with docker
```
$ nextflow run toParquet.nf -profile standard,docker
```

or on any of LSF, SLURM, &c. with only configuration changes.

See
https://www.nextflow.io/docs/latest/executor.html

The scripts themselves are essentially `find . -name *.gfa | ...` with parallel downstream processes.